### PR TITLE
Improve frame capture and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,34 @@
-# React + TypeScript + Vite
+# Video Frame Capture Tool
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A small React + TypeScript application that lets you upload a video and download any frame as an image.
 
-Currently, two official plugins are available:
+## Features
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Drag & drop or select a video file to load it
+- Seek with a slider and play controls
+- Capture the first, current or last frame as a PNG file
+- Video playback position is restored after capturing
+- Object URLs are cleaned up when the video changes
 
-## Expanding the ESLint configuration
+## Development
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+Install dependencies and start the dev server:
 
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
+npm run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Open your browser at the printed local address to use the tool.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+To create a production build:
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm run build
+```
+
+Lint the project:
+
+```bash
+npm run lint
 ```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, type ChangeEvent } from 'react';
+import { useState, useRef, useEffect, type ChangeEvent } from 'react';
 import './App.css';
 
 function App() {
@@ -7,6 +7,14 @@ function App() {
   const [currentTime, setCurrentTime] = useState(0);
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    return () => {
+      if (videoSrc) {
+        URL.revokeObjectURL(videoSrc);
+      }
+    };
+  }, [videoSrc]);
 
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -38,6 +46,8 @@ function App() {
       if (context) {
         canvas.width = video.videoWidth;
         canvas.height = video.videoHeight;
+        const originalTime = video.currentTime;
+        const wasPaused = video.paused;
 
         const drawImageAndDownload = () => {
           context.drawImage(video, 0, 0, video.videoWidth, video.videoHeight);
@@ -50,6 +60,14 @@ function App() {
           link.click();
           document.body.removeChild(link);
           video.onseeked = null; // Clean up the event listener
+          video.currentTime = originalTime;
+          if (!wasPaused) {
+            // Resume playback if the video was playing
+            const playPromise = video.play();
+            if (playPromise !== undefined) {
+              playPromise.catch(() => {});
+            }
+          }
         };
 
         video.onseeked = drawImageAndDownload;


### PR DESCRIPTION
## Summary
- handle object URL cleanup on video change
- keep playback position when capturing a frame
- document the project and features in README

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/first_last_zhen/node_modules/globals/index.js')*
- `npm run build` *(fails: Cannot find type definition file for 'babel__core')*

------
https://chatgpt.com/codex/tasks/task_e_68837e9f49f0832ea93307a0c653704f